### PR TITLE
Shade protobuf dependency to fix version conflicts with Apache Spark

### DIFF
--- a/hadoop/README.md
+++ b/hadoop/README.md
@@ -37,7 +37,7 @@ installed.
     mvn install
     ```
 
-    After installed (or deployed), the package can be used with following dependency:
+    After installation (or deployment), the package can be used with the following dependency:
 
     ```xml
     <dependency>
@@ -47,15 +47,37 @@ installed.
     </dependency>
     ```
 
+    Alternatively, use the shaded version of the package in case of incompatibilities with the version
+    of the protobuf library in your application. For example, Apache Spark uses an older version of the
+    protobuf library which can cause conflicts. The shaded package can be used as follows:
+
+    ```xml
+    <dependency>
+      <groupId>org.tensorflow</groupId>
+      <artifactId>tensorflow-hadoop</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <classifier>shaded-protobuf</classifier>
+    </dependency>
+    ```
+
 ## Use with MapReduce
 The Hadoop MapReduce example can be found [here](src/main/java/org/tensorflow/hadoop/example/TFRecordFileMRExample.java).
 
 ## Use with Spark
-Spark support reading/writing files with Hadoop InputFormat/OutputFormat, the
-following code snippet demostrate the usage.
+Spark supports reading/writing files with Hadoop InputFormat/OutputFormat. Use the shaded version of the
+package to avoid conflicts with the protobuf version included in Spark.
+
+The following command demonstrates how to use the package with spark-shell:
+
+```bash
+$spark-shell --master local --jars target/tensorflow-hadoop-1.0-SNAPSHOT-shaded-protobuf.jar
+```
+
+
+The following code snippet demonstrates the usage.
 
 ```scala
-import com.google.protobuf.ByteString
+import org.tensorflow.hadoop.shaded.protobuf.ByteString
 import org.apache.hadoop.io.{NullWritable, BytesWritable}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.tensorflow.example.{BytesList, Int64List, Feature, Features, Example}

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -16,7 +16,58 @@
         <hadoop.version>2.6.0</hadoop.version>
         <protobuf.version>3.1.0</protobuf.version>
         <junit.version>4.11</junit.version>
+        <!-- Package to use when relocating shaded classes. -->
+        <tensorflow.shade.packageName>org.tensorflow.hadoop.shaded</tensorflow.shade.packageName>
     </properties>
+
+    <licenses>
+        <license>
+            <name>Apache License Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <!-- Shade protobuf dependency. -->
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded-protobuf</shadedClassifierName>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.protobuf:protobuf-java</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- Remove the source to keep the result smaller. -->
+                                    <artifact>com.google.protobuf:protobuf-java</artifact>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>${tensorflow.shade.packageName}.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Apache Spark uses an older version of the protobuf library included in Apache hadoop-common. This fix uses Maven shading to resolve the version conflicts.

Without shading, the following exception is thrown when using the package in spark-shell or when running in yarn-client or yarn-cluster mode with Apache Spark: ```java.lang.NoSuchMethodError: com.google.protobuf.Descriptors$Descriptor.getOneofs()Ljava/util/List; at com.google.protobuf.GeneratedMessageV3$FieldAccessorTable.<init>(```

The fix is based on the approach used by Apache Mesos to resolve protobuf conflicts with Spark.
