### PR TITLE
Add support for encoding BinaryType directly to BytesList

### DIFF
--- a/spark/spark-tensorflow-connector/README.md
+++ b/spark/spark-tensorflow-connector/README.md
@@ -85,7 +85,7 @@ The supported Spark data types are listed in the table below:
 
 | Type            | Spark DataTypes                          |
 | --------------- |:------------------------------------------|
-| Scalar          | IntegerType, LongType, FloatType, DoubleType, DecimalType, StringType |
+| Scalar          | IntegerType, LongType, FloatType, DoubleType, DecimalType, StringType, BinaryType |
 | Array           | VectorType, ArrayType of IntegerType, LongType, FloatType, DoubleType, DecimalType, or StringType |
 | Array of Arrays | ArrayType of ArrayType of IntegerType, LongType, FloatType, DoubleType, DecimalType, or StringType |
 

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
@@ -115,7 +115,8 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
       case FloatType => FloatListFeatureEncoder.encode(Seq(row.getFloat(index)))
       case DoubleType => FloatListFeatureEncoder.encode(Seq(row.getDouble(index).toFloat))
       case DecimalType() => FloatListFeatureEncoder.encode(Seq(row.getAs[Decimal](index).toFloat))
-      case StringType => BytesListFeatureEncoder.encode(Seq(row.getString(index)))
+      case StringType => BytesListFeatureEncoder.encode(Seq(row.getString(index).getBytes))
+      case BinaryType => BytesListFeatureEncoder.encode(Seq(row.getAs[Array[Byte]](index)))
       case ArrayType(IntegerType, _)  =>
         Int64ListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toIntArray().map(_.toLong))
       case ArrayType(LongType, _) =>
@@ -127,8 +128,8 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
       case ArrayType(DecimalType(), _) =>
         val decimalArray = ArrayData.toArrayData(row.get(index)).toArray[Decimal](DataTypes.createDecimalType())
         FloatListFeatureEncoder.encode(decimalArray.map(_.toFloat))
-      case ArrayType(_, _) =>
-        BytesListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toArray[String](StringType))
+      case ArrayType(StringType, _) =>
+        BytesListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toArray[String](StringType).map(_.getBytes))
       case VectorType => {
         val field = row.get(index)
         field match {
@@ -177,7 +178,7 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
 
       case ArrayType(ArrayType(StringType, _), _) =>
         val arrayData = ArrayData.toArrayData(row.get(index)).array.map {arr =>
-          ArrayData.toArrayData(arr).toArray[String](StringType).toSeq
+          ArrayData.toArrayData(arr).toArray[String](StringType).toSeq.map(_.getBytes)
         }.toSeq
         BytesFeatureListEncoder.encode(arrayData)
 

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureEncoder.scala
@@ -61,11 +61,11 @@ object FloatListFeatureEncoder extends FeatureEncoder[Seq[Float]] {
 /**
  * Encode input value to ByteList
  */
-object BytesListFeatureEncoder extends FeatureEncoder[Seq[String]] {
-  override def encode(value: Seq[String]): Feature = {
+object BytesListFeatureEncoder extends FeatureEncoder[Seq[Array[Byte]]] {
+  override def encode(value: Seq[Array[Byte]]): Feature = {
     val bytesListBuilder = BytesList.newBuilder()
     value.foreach {x =>
-      bytesListBuilder.addValue(ByteString.copyFrom(x.getBytes))
+      bytesListBuilder.addValue(ByteString.copyFrom(x))
     }
     val bytesList = bytesListBuilder.build()
     Feature.newBuilder().setBytesList(bytesList).build()

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureListEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureListEncoder.scala
@@ -61,8 +61,8 @@ object FloatFeatureListEncoder extends FeatureListEncoder[Seq[Seq[Float]]] {
 /**
  * Encode 2-dimensional String array to TensorFlow "FeatureList" of type BytesList
  */
-object BytesFeatureListEncoder extends FeatureListEncoder[Seq[Seq[String]]] {
-  def encode(value: Seq[Seq[String]]) : FeatureList = {
+object BytesFeatureListEncoder extends FeatureListEncoder[Seq[Seq[Array[Byte]]]] {
+  def encode(value: Seq[Seq[Array[Byte]]]) : FeatureList = {
     val builder =  FeatureList.newBuilder()
     value.foreach { x =>
       val bytesList = BytesListFeatureEncoder.encode(x)

--- a/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureEncoderTest.scala
+++ b/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureEncoderTest.scala
@@ -53,16 +53,16 @@ class FeatureEncoderTest extends WordSpec with Matchers {
 
   "ByteList feature encoder" should {
     "Encode inputs to ByteList" in {
-      val strFeature = BytesListFeatureEncoder.encode(Seq("str-input"))
-      val strListFeature = BytesListFeatureEncoder.encode(Seq("alice", "bob"))
+      val binFeature = BytesListFeatureEncoder.encode(Seq(Array(0xff.toByte, 0xd8.toByte)))
+      val binListFeature = BytesListFeatureEncoder.encode(Seq(Array(0xff.toByte, 0xd8.toByte), Array(0xff.toByte, 0xd9.toByte)))
 
-      assert(strFeature.getBytesList.getValueList.asScala.map(_.toStringUtf8) === Seq("str-input"))
-      assert(strListFeature.getBytesList.getValueList.asScala.map(_.toStringUtf8) === Seq("alice", "bob"))
+      assert(binFeature.getBytesList.getValueList.asScala.toSeq.map(_.toByteArray.deep) === Seq(Array(0xff.toByte, 0xd8.toByte).deep))
+      assert(binListFeature.getBytesList.getValueList.asScala.map(_.toByteArray.deep) === Seq(Array(0xff.toByte, 0xd8.toByte).deep, Array(0xff.toByte, 0xd9.toByte).deep))
     }
 
     "Encode empty list to empty feature" in {
-      val strListFeature = BytesListFeatureEncoder.encode(Seq.empty[String])
-      assert(strListFeature.getBytesList.getValueList.size() === 0)
+      val binListFeature = BytesListFeatureEncoder.encode(Seq.empty[Array[Byte]])
+      assert(binListFeature.getBytesList.getValueList.size() === 0)
     }
   }
 }

--- a/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureListEncoderTest.scala
+++ b/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/serde/FeatureListEncoderTest.scala
@@ -52,18 +52,18 @@ class FeatureListEncoderTest extends WordSpec with Matchers {
     }
   }
 
-  "String feature list encoder" should {
+  "Bytes feature list encoder" should {
 
-    "Encode inputs to feature list of string" in {
-      val stringListOfLists = Seq(Seq("alice", "bob"), Seq("charles"))
-      val stringFeatureList = BytesFeatureListEncoder.encode(stringListOfLists)
+    "Encode inputs to feature list of bytes" in {
+      val bytesListOfLists = Seq(Seq("alice".getBytes, "bob".getBytes), Seq("charles".getBytes))
+      val bytesFeatureList = BytesFeatureListEncoder.encode(bytesListOfLists)
 
-      assert(stringFeatureList.getFeatureList.asScala.map(_.getBytesList.getValueList.asScala.map(_.toStringUtf8).toSeq) === stringListOfLists)
+      assert(bytesFeatureList.getFeatureList.asScala.map(_.getBytesList.getValueList.asScala.toSeq.map(_.toByteArray.deep)) === bytesListOfLists.map(_.map(_.deep)))
     }
 
     "Encode empty array to empty feature list" in {
-      val stringFeatureList = BytesFeatureListEncoder.encode(Seq.empty[Seq[String]])
-      assert(stringFeatureList.getFeatureList.size() === 0)
+      val bytesFeatureList = BytesFeatureListEncoder.encode(Seq.empty[Seq[Array[Byte]]])
+      assert(bytesFeatureList.getFeatureList.size() === 0)
     }
   }
 }


### PR DESCRIPTION
Previously, it was necessary to cast binary data to strings before saving it. This generally lead to the inability to recover the data due to complications with unicode, character encodings, etc.

This PR makes `BinaryType`(= `Array[Byte]`) to `BytesList` the primary encoder, and includes a conversion  from `String` to `Array[Byte]` where necessary to preserve the present functionality.

In the future, one might wish to make this change for the decoder as well, so that a `BytesList` resolves to `BinaryType`. This gives the user more control over character encodings in the case of string data, and prevents issues if it is in fact binary data. This would modify current behavior, so it's not done here.

Resolves #60 