### PR TITLE
Update artifact ids for Spark and Hadoop jars

### DIFF
--- a/hadoop/README.md
+++ b/hadoop/README.md
@@ -11,6 +11,10 @@ This can also be used with [Apache Spark](http://spark.apache.org/).
 2. Tested with Hadoop 2.6.0. Patches are welcome if there are incompatibilities
    with your Hadoop version.
 
+## Changelog
+
+* 05/29/2018 - Changed the artifactId from `org.tensorflow.tensorflow-hadoop` to `org.tensorflow.hadoop`
+
 ## Build and install
 
 1. Compile the code
@@ -37,8 +41,8 @@ This can also be used with [Apache Spark](http://spark.apache.org/).
     ```xml
     <dependency>
       <groupId>org.tensorflow</groupId>
-      <artifactId>tensorflow-hadoop</artifactId>
-      <version>1.6.0</version>
+      <artifactId>hadoop</artifactId>
+      <version>1.8.0</version>
     </dependency>
     ```
 

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -118,7 +118,8 @@
                 <!-- Sonatype requirements from http://central.sonatype.org/pages/apache-maven.html -->
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://tap.jfrog.io/tap/public-snapshots</url>
+                    <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
                 </snapshotRepository>
                 <repository>
                     <id>ossrh</id>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>tensorflow-hadoop</artifactId>
+    <artifactId>hadoop</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.0</version>
+    <version>1.8.0</version>
     <name>tensorflow-hadoop</name>
     <url>https://www.tensorflow.org</url>
     <description>TensorFlow TFRecord InputFormat/OutputFormat for Apache Hadoop</description>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -118,8 +118,7 @@
                 <!-- Sonatype requirements from http://central.sonatype.org/pages/apache-maven.html -->
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://tap.jfrog.io/tap/public-snapshots</url>
-                    <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
                 <repository>
                     <id>ossrh</id>

--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -226,7 +226,8 @@
                 <!-- Sonatype requirements from http://central.sonatype.org/pages/apache-maven.html -->
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <url>https://tap.jfrog.io/tap/public-snapshots</url>
+                    <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
                 </snapshotRepository>
                 <repository>
                     <id>ossrh</id>

--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-tensorflow-connector_2.11</artifactId>
+    <artifactId>spark-connector_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.0</version>
+    <version>1.8.0</version>
     <name>spark-tensorflow-connector</name>
     <url>https://www.tensorflow.org</url>
     <description>TensorFlow TFRecord connector for Apache Spark DataFrames</description>
@@ -114,7 +114,7 @@
                                 <artifactSet>
                                     <includes>
                                         <include>com.google.protobuf:protobuf-java</include>
-                                        <include>org.tensorflow:tensorflow-hadoop</include>
+                                        <include>org.tensorflow:hadoop</include>
                                         <include>org.tensorflow:proto</include>
                                     </includes>
                                 </artifactSet>
@@ -273,7 +273,7 @@
     <dependencies>
         <dependency>
             <groupId>org.tensorflow</groupId>
-            <artifactId>tensorflow-hadoop</artifactId>
+            <artifactId>hadoop</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -226,8 +226,7 @@
                 <!-- Sonatype requirements from http://central.sonatype.org/pages/apache-maven.html -->
                 <snapshotRepository>
                     <id>ossrh</id>
-                    <url>https://tap.jfrog.io/tap/public-snapshots</url>
-                    <!--<url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
                 <repository>
                     <id>ossrh</id>


### PR DESCRIPTION
@jhseu @asimshankar I updated the artifact IDs in the poms as requested in https://github.com/tensorflow/tensorflow/pull/19188 so tensorflow-hadoop is now hadoop, and tensorflow-spark-connector is now spark-connector

I also fixed the youtube-8m example in the Spark connector README to address changes in the download procedure.