### PR TITLE
Fixing javaDocs errors

### DIFF
--- a/hadoop/src/main/java/org/tensorflow/hadoop/util/Crc32C.java
+++ b/hadoop/src/main/java/org/tensorflow/hadoop/util/Crc32C.java
@@ -35,10 +35,13 @@ public class Crc32C implements Checksum {
 
   /**
    * Return a masked representation of crc.
-   * <p/>
-   * Motivation: it is problematic to compute the CRC of a string that
-   * contains embedded CRCs.  Therefore we recommend that CRCs stored
-   * somewhere (e.g., in files) should be masked before being stored.
+   * <p>
+   *  Motivation: it is problematic to compute the CRC of a string that
+   *  contains embedded CRCs.  Therefore we recommend that CRCs stored
+   *  somewhere (e.g., in files) should be masked before being stored.
+   * </p>
+   * @param crc CRC
+   * @return masked CRC
    */
   public static int mask(int crc) {
     // Rotate right by 15 bits and add a constant.
@@ -47,6 +50,8 @@ public class Crc32C implements Checksum {
 
   /**
    * Return the crc whose masked representation is masked_crc.
+   * @param maskedCrc masked CRC
+   * @return crc whose masked representation is masked_crc
    */
   public static int unmask(int maskedCrc) {
     int rot = maskedCrc - MASK_DELTA;


### PR DESCRIPTION
Since javaDocs are added in commit 838b3238e59adae4a8492aecd0fc36cd872ccbf0, maven cannot compile javaDocs with error. The errors are:
[ERROR] Exit code: 1 : ecosystem/hadoop/src/main/java/org/tensorflow/hadoop/util/Crc32C.java:38: error: self-closing element not allowed

Also Maven gives warning on params that are not defined in the javaDoc.

This pull request fixes the errors in JavaDocs