### PR TITLE
Update DefaultTfRecordRowEncoder to be compatible with Spark 2.4

### DIFF
--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -33,7 +33,7 @@
         <scala.test.version>2.2.6</scala.test.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
-        <spark.version>2.3.0</spark.version>
+        <spark.version>2.4.0-SNAPSHOT</spark.version>
         <yarn.api.version>2.7.3</yarn.api.version>
         <junit.version>4.11</junit.version>
     </properties>
@@ -212,6 +212,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Development Snapshot Repository</name>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <profiles>
         <profile>

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
@@ -129,7 +129,8 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
         val decimalArray = ArrayData.toArrayData(row.get(index)).toArray[Decimal](DataTypes.createDecimalType())
         FloatListFeatureEncoder.encode(decimalArray.map(_.toFloat))
       case ArrayType(StringType, _) =>
-        BytesListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toArray[String](StringType).map(_.getBytes))
+        BytesListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index))
+          .toArray[String](ObjectType(classOf[String])).map(_.getBytes))
       case ArrayType(BinaryType, _) =>
         BytesListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toArray[Array[Byte]](BinaryType))
       case VectorType => {
@@ -180,7 +181,7 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
 
       case ArrayType(ArrayType(StringType, _), _) =>
         val arrayData = ArrayData.toArrayData(row.get(index)).array.map {arr =>
-          ArrayData.toArrayData(arr).toArray[String](StringType).toSeq.map(_.getBytes)
+          ArrayData.toArrayData(arr).toArray[String](ObjectType(classOf[String])).toSeq.map(_.getBytes)
         }.toSeq
         BytesFeatureListEncoder.encode(arrayData)
 


### PR DESCRIPTION
There is an `ArrayData.toArray` behavior change in the upcoming 2.4, where `StringType` maps to `UTF8String`. The tests failed with type cast error. This PR updates the implementation to make it compatible. Added Apache snapshot repo to get Spark 2.4 SNAPSHOT jar.