### PR TITLE
Shade tensorflow-hadoop jar

### DIFF
--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -140,6 +140,12 @@
                                             org.tensorflow.spark.shaded.com.google.protobuf
                                         </shadedPattern>
                                     </relocation>
+                                    <relocation>
+                                        <pattern>org.tensorflow.hadoop</pattern>
+                                        <shadedPattern>
+                                            org.tensorflow.spark.shaded.org.tensorflow.hadoop
+                                        </shadedPattern>
+                                    </relocation>
                                 </relocations>
                             </configuration>
                         </execution>


### PR DESCRIPTION
We have seen that certain implementations of tensorflow provide their own tensorflow-hadoop dependency which comes in conflict with spark-tensorflow-connector jar dependencies. Thus, shading tensorflow-hadoop jar would be a better alternative here.