### PR TITLE
add new `codec` option for compression in Spark-Tensorflow connector

### DIFF
--- a/spark/spark-tensorflow-connector/README.md
+++ b/spark/spark-tensorflow-connector/README.md
@@ -80,6 +80,8 @@ When reading TensorFlow records into Spark DataFrame, the API accepts several op
 
 When writing Spark DataFrame to TensorFlow records, the API accepts several options:
 * `save`: output path to TensorFlow records. Output path to TensorFlow records on local or distributed filesystem.
+* `codec`: codec for compressinng Tensorflow records. For example, `option("codec", "org.apache.hadoop.io.compress.GzipCodec")` enables gzip
+compression. While reading compressed TensorFlow records, `codec` can be inferred automatically, so this option is not required for reading.
 * `recordType`: output format of TensorFlow records. By default it is Example. Possible values are:
   * `Example`: TensorFlow [Example](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records
   * `SequenceExample`: TensorFlow [SequenceExample](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/example/example.proto) records


### PR DESCRIPTION
With https://github.com/tensorflow/ecosystem/pull/125, it became possible to output gzipped TFrecords by setting `spark.hadoop.mapreduce.output.fileoutputformat.compress` in the global `SparkConf`.
However, there's no way to only enable compression for individual DataFrame outputs.

This PR adds a new option `codec` to the Spark-Tensorflow connector for enabling compression in individual DataFrameWriter. With this, we don't need to set `spark.hadoop.mapreduce.output.fileoutputformat.compress` globally anymore.

Sample usage:
```
(
  dataframe
  .write
  .format('tfrecords')
  .option('codec', 'org.apache.hadoop.io.compress.GzipCodec')
  .save('sample.tfrecord.gz')
)
```