### PR TITLE
fix Array[String] for SequenceExample

### DIFF
--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
@@ -93,7 +93,7 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
         }
       }
       case (structField, index) => structField.dataType match {
-        case ArrayType(ArrayType(_, _), _) | ArrayType(StringType, _) =>
+        case ArrayType(ArrayType(_, _), _) =>
           val featureList = encodeFeatureList(row, structField, index)
           featureLists.putFeatureList(structField.name, featureList)
         case _ =>


### PR DESCRIPTION
ArrayType(String) should be a Feature not a FeatureList.

If row element is ArrayType(StringType, _),  it will go to https://github.com/tensorflow/ecosystem/blob/master/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala#L194, triger a RuntimeException.
```scala
case _ => throw new RuntimeException(s"Cannot convert row element ${row.get(index)} to FeatureList.")
```