### PR TITLE
Fix flaky test "LocalWriteSuite"

### DIFF
--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-tensorflow-connector_2.11</artifactId>
+    <artifactId>spark-tensorflow-connector_2.12</artifactId>
     <packaging>jar</packaging>
     <version>1.10.0</version>
     <name>spark-tensorflow-connector</name>

--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-tensorflow-connector_2.12</artifactId>
+    <artifactId>spark-tensorflow-connector_2.11</artifactId>
     <packaging>jar</packaging>
     <version>1.10.0</version>
     <name>spark-tensorflow-connector</name>

--- a/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/LocalWriteSuite.scala
+++ b/spark/spark-tensorflow-connector/src/test/scala/org/tensorflow/spark/datasources/tfrecords/LocalWriteSuite.scala
@@ -22,6 +22,8 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.types._
 
+import org.apache.commons.io.FileUtils
+
 class LocalWriteSuite extends SharedSparkSessionSuite {
 
   val testRows: Array[Row] = Array(
@@ -49,19 +51,18 @@ class LocalWriteSuite extends SharedSparkSessionSuite {
       // In a distributed setting though, two different machines would each hold a single
       // partition.
       val localPath = Files.createTempDirectory("spark-connector-propagate").toAbsolutePath.toString
-      // Delete the directory, the default mode is ErrorIfExists
-      Files.delete(Paths.get(localPath))
+      val savePath = localPath + "/testResult"
       df.write.format("tfrecords")
         .option("recordType", "Example")
         .option("writeLocality", "local")
-        .save(localPath)
+        .save(savePath)
 
       // Read again this directory, this time using the Hadoop file readers, it should
       // return the same data.
       // This only works in this test and does not hold in general, because the partitions
       // will be written on the workers. Everything runs locally for tests.
       val df2 = spark.read.format("tfrecords").option("recordType", "Example")
-        .load(localPath).sort("id").select("id", "IntegerTypeLabel", "LongTypeLabel",
+        .load(savePath).sort("id").select("id", "IntegerTypeLabel", "LongTypeLabel",
         "FloatTypeLabel", "DoubleTypeLabel", "VectorLabel", "name") // Correct column order.
 
       assert(df2.collect().toSeq === testRows.toSeq)


### PR DESCRIPTION
Fix flaky test "LocalWriteSuite"

The issue is in:

The test first create a temporary path by `java.nio.Files.createTempDirectory`, then delete it, then use the allocated temp path to be the saving path for dataframe.
This is risky. because when we delete a directory, the path is released and can be allocated as new temp dir in other place, which cause the next line `df.save` (errorIfExisting mode) failed.

So I update the code. Do not delete the created temp dir, but create a sub-dir inside it as the df saving destination.