### PR TITLE
Support scala 2.12.10 and spark 2.4.4

### DIFF
--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-tensorflow-connector_2.11</artifactId>
+    <artifactId>spark-tensorflow-connector_${scala.binary.version}</artifactId>
     <packaging>jar</packaging>
     <version>1.10.0</version>
     <name>spark-tensorflow-connector</name>
@@ -27,13 +27,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.maven.version>3.2.2</scala.maven.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.maven.version>4.3.0</scala.maven.version>
+        <scala.version>2.12.10</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <scalatest.maven.version>1.0</scalatest.maven.version>
-        <scala.test.version>2.2.6</scala.test.version>
+        <scala.test.version>3.0.8</scala.test.version>
         <maven.compiler.version>3.0</maven.compiler.version>
         <java.version>1.8</java.version>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.4.4</spark.version>
         <yarn.api.version>2.7.3</yarn.api.version>
         <junit.version>4.11</junit.version>
     </properties>
@@ -86,7 +87,7 @@
                     <configuration>
                         <recompileMode>incremental</recompileMode>
                         <useZincServer>true</useZincServer>
-                        <scalaVersion>${scala.binary.version}</scalaVersion>
+                        <scalaVersion>${scala.version}</scalaVersion>
                         <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
                     </configuration>
                 </plugin>

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/DefaultSource.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/DefaultSource.scala
@@ -167,7 +167,7 @@ class DefaultSource extends DataSourceRegister
   }
 }
 
-object DefaultSource {
+object DefaultSource extends scala.Serializable {
   // The function run on each worker.
   // Writes the partition to a file and returns the number of records output.
   private def writePartitionLocal(
@@ -189,7 +189,7 @@ object DefaultSource {
     // Make the directory if it does not exist
     dir.mkdirs()
     // The path to the partition file.
-    val filePath = localPath + s"/part-" + String.format("%05d", new java.lang.Integer(index))
+    val filePath = localPath + s"/part-" + String.format("%05d", java.lang.Integer.valueOf(index))
     val fos = new DataOutputStream(new FileOutputStream(filePath))
     var count = 0
     try {


### PR DESCRIPTION
Hello.

Related to https://github.com/tensorflow/ecosystem/pull/141#issuecomment-618852587

Not sure whether it'd be better to support multiple scala versions, perhaps introducing multiple profiles could be a good idea. As I understood from the comments https://github.com/tensorflow/ecosystem/pull/141 scala 2.11 could be left behind. Please let me know if I understood it incorrectly.

Tested with:
```
mvn clean install
```