### PR TITLE
BooleanType support

### DIFF
--- a/spark/spark-tensorflow-connector/README.md
+++ b/spark/spark-tensorflow-connector/README.md
@@ -131,8 +131,8 @@ The supported Spark data types are listed in the table below:
 
 | Type            | Spark DataTypes                          |
 | --------------- |:------------------------------------------|
-| Scalar          | IntegerType, LongType, FloatType, DoubleType, DecimalType, StringType, BinaryType |
-| Array           | VectorType, ArrayType of IntegerType, LongType, FloatType, DoubleType, DecimalType, BinaryType, or StringType |
+| Scalar          | IntegerType, LongType, FloatType, DoubleType, DecimalType, StringType, BinaryType, BooleanType |
+| Array           | VectorType, ArrayType of IntegerType, LongType, FloatType, DoubleType, DecimalType, BooleanType, BinaryType, or StringType |
 | Array of Arrays | ArrayType of ArrayType of IntegerType, LongType, FloatType, DoubleType, DecimalType, BinaryType, or StringType |
 
 ## Usage Examples

--- a/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
+++ b/spark/spark-tensorflow-connector/src/main/scala/org/tensorflow/spark/datasources/tfrecords/serde/DefaultTfRecordRowEncoder.scala
@@ -111,12 +111,15 @@ object DefaultTfRecordRowEncoder extends TfRecordRowEncoder {
   private def encodeFeature(row: Row, structField: StructField, index: Int): Feature = {
     val feature = structField.dataType match {
       case IntegerType => Int64ListFeatureEncoder.encode(Seq(row.getInt(index).toLong))
+      case BooleanType =>   Int64ListFeatureEncoder.encode(Seq(if (row.getBoolean(index)) 1.toLong else 0.toLong))
       case LongType => Int64ListFeatureEncoder.encode(Seq(row.getLong(index)))
       case FloatType => FloatListFeatureEncoder.encode(Seq(row.getFloat(index)))
       case DoubleType => FloatListFeatureEncoder.encode(Seq(row.getDouble(index).toFloat))
       case DecimalType() => FloatListFeatureEncoder.encode(Seq(row.getAs[Decimal](index).toFloat))
       case StringType => BytesListFeatureEncoder.encode(Seq(row.getString(index).getBytes))
       case BinaryType => BytesListFeatureEncoder.encode(Seq(row.getAs[Array[Byte]](index)))
+      case ArrayType(BooleanType, _) =>
+        Int64ListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toBooleanArray().map(if (_) 1.toLong else 0.toLong))
       case ArrayType(IntegerType, _)  =>
         Int64ListFeatureEncoder.encode(ArrayData.toArrayData(row.get(index)).toIntArray().map(_.toLong))
       case ArrayType(LongType, _) =>


### PR DESCRIPTION
Converting a Dataframe with a  `BooleanType` column ends up in exceptions as that type is not in the mapping.
This PR adds `BooleanType` to the mapping. Not sure if it was left intentionally  out, if so it would be good to document it.

Thanks for this project, indeed very useful.
