### PR TITLE
Update the example for spark-tensorflow-distributor

### DIFF
--- a/spark/spark-tensorflow-distributor/README.md
+++ b/spark/spark-tensorflow-distributor/README.md
@@ -49,26 +49,22 @@ Run following example code in `pyspark` shell:
 ```python
 from spark_tensorflow_distributor import MirroredStrategyRunner
 
-
-# Taken from https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras
+# Adapted from https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras
 def train():
-    import tensorflow_datasets as tfds
     import tensorflow as tf
     BUFFER_SIZE = 10000
     BATCH_SIZE = 64
 
-    def make_datasets_unbatched():
-        # Scaling MNIST data from (0, 255] to (0., 1.]
-        def scale(image, label):
-            image = tf.cast(image, tf.float32)
-            image /= 255
-            return image, label
-        datasets, info = tfds.load(
-            name='mnist',
-            with_info=True,
-            as_supervised=True,
+    def make_datasets():
+        (mnist_images, mnist_labels), _ = \
+            tf.keras.datasets.mnist.load_data(path='mnist.npz')
+
+        dataset = tf.data.Dataset.from_tensor_slices((
+            tf.cast(mnist_images[..., tf.newaxis] / 255.0, tf.float32),
+            tf.cast(mnist_labels, tf.int64))
         )
-        return datasets['train'].map(scale).cache().shuffle(BUFFER_SIZE)
+        dataset = dataset.repeat().shuffle(BUFFER_SIZE).batch(BATCH_SIZE)
+        return dataset
 
     def build_and_compile_cnn_model():
         model = tf.keras.Sequential([
@@ -85,15 +81,13 @@ def train():
         )
         return model
 
-    GLOBAL_BATCH_SIZE = 64 * 8
-    train_datasets = make_datasets_unbatched().batch(GLOBAL_BATCH_SIZE).repeat()
+    train_datasets = make_datasets()
     options = tf.data.Options()
     options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.DATA
     train_datasets = train_datasets.with_options(options)
     multi_worker_model = build_and_compile_cnn_model()
     multi_worker_model.fit(x=train_datasets, epochs=3, steps_per_epoch=5)
-    return tf.config.experimental.list_physical_devices('GPU')
 
-MirroredStrategyRunner(num_slots=4).run(train)
+MirroredStrategyRunner(num_slots=8).run(train)
 ```
 

--- a/spark/spark-tensorflow-distributor/examples/simple/example.py
+++ b/spark/spark-tensorflow-distributor/examples/simple/example.py
@@ -1,25 +1,21 @@
 from spark_tensorflow_distributor import MirroredStrategyRunner
 
-
-# Taken from https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras
+# Adapted from https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras
 def train():
-    import tensorflow_datasets as tfds
     import tensorflow as tf
     BUFFER_SIZE = 10000
     BATCH_SIZE = 64
 
-    def make_datasets_unbatched():
-        # Scaling MNIST data from (0, 255] to (0., 1.]
-        def scale(image, label):
-            image = tf.cast(image, tf.float32)
-            image /= 255
-            return image, label
-        datasets, info = tfds.load(
-            name='mnist',
-            with_info=True,
-            as_supervised=True,
+    def make_datasets():
+        (mnist_images, mnist_labels), _ = \
+            tf.keras.datasets.mnist.load_data(path='mnist.npz')
+
+        dataset = tf.data.Dataset.from_tensor_slices((
+            tf.cast(mnist_images[..., tf.newaxis] / 255.0, tf.float32),
+            tf.cast(mnist_labels, tf.int64))
         )
-        return datasets['train'].map(scale).cache().shuffle(BUFFER_SIZE)
+        dataset = dataset.repeat().shuffle(BUFFER_SIZE).batch(BATCH_SIZE)
+        return dataset
 
     def build_and_compile_cnn_model():
         model = tf.keras.Sequential([
@@ -36,13 +32,11 @@ def train():
         )
         return model
 
-    GLOBAL_BATCH_SIZE = 64 * 8
-    train_datasets = make_datasets_unbatched().batch(GLOBAL_BATCH_SIZE).repeat()
+    train_datasets = make_datasets()
     options = tf.data.Options()
     options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.DATA
     train_datasets = train_datasets.with_options(options)
     multi_worker_model = build_and_compile_cnn_model()
     multi_worker_model.fit(x=train_datasets, epochs=3, steps_per_epoch=5)
-    return tf.config.experimental.list_physical_devices('GPU')
 
-MirroredStrategyRunner(num_slots=4).run(train)
+MirroredStrategyRunner(num_slots=8).run(train)


### PR DESCRIPTION
This PR fixes the data downloading issue in the example code.

Reproduce: On a cluster with multiple GPUs per worker node, with spark.resources.tasks.gpu.amount set to 1, running the original example will trigger an error related to data downloading.

Cause: There will be multiple tasks running on the same worker and each task will try to write the data to the same path, which will corrupt the data.

Fix: Randomize the file path.