### PR TITLE
Spark 3.0.0 with Scala 2.12

### DIFF
--- a/spark/spark-tensorflow-connector/pom.xml
+++ b/spark/spark-tensorflow-connector/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tensorflow</groupId>
-    <artifactId>spark-tensorflow-connector_${scala.binary.version}</artifactId>
+    <artifactId>spark-tensorflow-connector_2.12</artifactId>
     <packaging>jar</packaging>
-    <version>1.10.0</version>
+    <version>1.11.0</version>
     <name>spark-tensorflow-connector</name>
     <url>https://www.tensorflow.org</url>
     <description>TensorFlow TFRecord connector for Apache Spark DataFrames</description>
@@ -28,13 +28,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.maven.version>4.3.0</scala.maven.version>
-        <scala.version>2.12.10</scala.version>
+        <scala.version>2.12.12</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scalatest.maven.version>1.0</scalatest.maven.version>
         <scala.test.version>3.0.8</scala.test.version>
-        <maven.compiler.version>3.0</maven.compiler.version>
+        <maven.compiler.version>3.8.1</maven.compiler.version>
         <java.version>1.8</java.version>
-        <spark.version>2.4.4</spark.version>
+        <spark.version>3.0.0</spark.version>
         <yarn.api.version>2.7.3</yarn.api.version>
         <junit.version>4.11</junit.version>
     </properties>


### PR DESCRIPTION
Spark 3.0.0 was officially released in June. The project is providing Scala 2.12 binaries.

I think the Tensorflow connector should now be targeting this newer version of Spark by default, and perhaps Spark 2.x in a branch. Spark 2.4.7 and other maintenance releases are likely in future, but I expect they will be bug fixes and backports or new features.