### PR TITLE
Update data_service.yaml.jinja to use non-deprecated GKE APIs.

### DIFF
--- a/data_service/data_service.yaml.jinja
+++ b/data_service/data_service.yaml.jinja
@@ -4,11 +4,14 @@
 } %}
 
 kind: ReplicaSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: data-service-dispatcher
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: data-service-dispatcher
   template:
     metadata:
       labels:
@@ -31,6 +34,9 @@ metadata:
   name: {{ worker_name }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: {{ worker_name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
ReplicaSet with extensions/v1beta1 were deprecated with GKE 1.16. This change updates the apiVersion it to the supported apps/v1.