### PR TITLE
Unbundle tensorflow from spark-tensorflow-distributor

### DIFF
--- a/spark/spark-tensorflow-distributor/README.md
+++ b/spark/spark-tensorflow-distributor/README.md
@@ -12,6 +12,8 @@ pip install spark-tensorflow-distributor
 ```
 
 The installation does not install PySpark because for most users, PySpark is already installed.
+In addition, `tensorflow` not installed so that users may choose between regular and CPU-only
+installation via `pip install tensorflow` and `pip install tensorflow-cpu`.
 If you do not have PySpark installed, you can install it directly:
 
 ```bash

--- a/spark/spark-tensorflow-distributor/requirements.txt
+++ b/spark/spark-tensorflow-distributor/requirements.txt
@@ -6,13 +6,11 @@
 ## Tensorflow Requirements ##
 # Tensorflow is required to run this code but depends on specific configurations. Install from:
 # https://www.tensorflow.org/get_started/os_setup#overview
+# Either `tensorflow` or `tensorflow-cpu` should be installed via pypi depending on if you want GPU support
 
 # NOTE: If you want to use the GPU version, you will also need Nvidia's CUDA toolkit and cuDNN:
 # https://developer.nvidia.com/cuda-downloads
 # https://developer.nvidia.com/cudnn
-# Note that if you want to use the GPU version, you have to `pip uninstall tensorflow`
-# and `pip install tensorflow-gpu`, since both cannot coexist. 
-tensorflow>=2.1.0
 
 # We'll use pytest to run our tests; this isn't really necessary to run the code, but it is to run
 # the tests.  With this here, you can run the tests with `py.test` from the base directory.

--- a/spark/spark-tensorflow-distributor/setup.py
+++ b/spark/spark-tensorflow-distributor/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
   name="spark_tensorflow_distributor",
-  version="0.0.3",
+  version="1.0.0",
   author="sarthfrey",
   author_email="sarth.frey@gmail.com",
   description="This package helps users do distributed training with TensorFlow on their Spark clusters.",
@@ -23,9 +23,6 @@ setuptools.setup(
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Version Control :: Git",
-  ],
-  install_requires=[
-    "tensorflow>=2.1.0",
   ],
   python_requires='>=3.6',
 )


### PR DESCRIPTION
I found many users wanted a CPU only version of tensorflow, and so it is better to unbundle tensorflow and make it clear that the user should install tensorflow themselves. Instructions are provided to do this in the diff.